### PR TITLE
Add build and push github action

### DIFF
--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -1,0 +1,36 @@
+name: Build and Push Image
+on: 
+  release:
+    types: [published]
+
+jobs:
+  build:
+    name: Build and push image
+    runs-on: ubuntu-20.04
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Build Image
+      id: build-image
+      uses: redhat-actions/buildah-build@v2
+      with:
+        image: vse-sync-testsuite
+        tags: latest ${{ github.sha }}
+        containerfiles: |
+          ./Containerfile
+
+    # Podman Login action (https://github.com/redhat-actions/podman-login) also be used to log in,
+    # in which case 'username' and 'password' can be omitted.
+    - name: Push To quay.io
+      id: push-to-quay
+      uses: redhat-actions/push-to-registry@v2
+      with:
+        image: ${{ steps.build-image.outputs.image }}
+        tags: ${{ steps.build-image.outputs.tags }}
+        registry: quay.io/redhat-partner-solutions
+        username: ${{ secrets.REGISTRY_USERNAME }}
+        password: ${{ secrets.REGISTRY_PASSWORD }}
+
+    - name: Print image url
+      run: echo "Image pushed to ${{ steps.push-to-quay.outputs.registry-paths }}"


### PR DESCRIPTION
Add build and push github action.

Prerequisites:
- Create the following secrets
  - REGISTRY_USERNAME
  - REGISTRY_PASSWORD
- This action is triggered by github release publish