### PR TITLE
Remove GPSD context and only use linuxptp-daemon-container

### DIFF
--- a/pkg/collectors/contexts/contexts.go
+++ b/pkg/collectors/contexts/contexts.go
@@ -22,11 +22,3 @@ func GetPTPDaemonContext(clientset *clients.Clientset) (clients.ContainerContext
 	}
 	return ctx, nil
 }
-
-func GetPTPgpsdContext(clientset *clients.Clientset) (clients.ContainerContext, error) {
-	ctx, err := clients.NewContainerContext(clientset, PTPNamespace, PTPPodNamePrefix, GPSContainer)
-	if err != nil {
-		return clients.ContainerContext{}, fmt.Errorf("could not create container context %w", err)
-	}
-	return ctx, nil
-}

--- a/pkg/collectors/gps_ubx_collector.go
+++ b/pkg/collectors/gps_ubx_collector.go
@@ -84,7 +84,7 @@ func (gps *GPSCollector) GetPollCount() int {
 
 // Returns a new GPSCollector based on values in the CollectionConstructor
 func NewGPSCollector(constructor *CollectionConstructor) (Collector, error) {
-	ctx, err := contexts.GetPTPgpsdContext(constructor.Clientset)
+	ctx, err := contexts.GetPTPDaemonContext(constructor.Clientset)
 	if err != nil {
 		return &GPSCollector{}, fmt.Errorf("failed to create DPLLCollector: %w", err)
 	}


### PR DESCRIPTION
The pre-GA PTP operator does not have a seperate container for gpds like our work around operator did.