### PR TITLE
Add PMC (PTP Management Client) collector

### DIFF
--- a/pkg/collectors/devices/pmc.go
+++ b/pkg/collectors/devices/pmc.go
@@ -1,0 +1,158 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package devices
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+
+	log "github.com/sirupsen/logrus"
+
+	"github.com/redhat-partner-solutions/vse-sync-collection-tools/pkg/callbacks"
+	"github.com/redhat-partner-solutions/vse-sync-collection-tools/pkg/clients"
+	"github.com/redhat-partner-solutions/vse-sync-collection-tools/pkg/fetcher"
+)
+
+type PMCInfo struct {
+	TimeSource              string `fetcherKey:"timeSource"              json:"timeSource"`
+	ClockAccuracy           string `fetcherKey:"clockAccuracy"           json:"clockAccuracy"`
+	OffsetScaledLogVariance string `fetcherKey:"offsetScaledLogVariance" json:"offsetScaledLogVariance"`
+	ClockClass              int    `fetcherKey:"clockClass"              json:"clockClass"`
+	CurrentUtcOffset        int    `fetcherKey:"currentUtcOffset"        json:"currentUtcOffset"`
+	Leap61                  int    `fetcherKey:"leap61"                  json:"leap61"`
+	Leap59                  int    `fetcherKey:"leap59"                  json:"leap59"`
+	CurrentUtcOffsetValid   int    `fetcherKey:"currentUtcOffsetValid"   json:"currentUtcOffsetValid"`
+	PtpTimescale            int    `fetcherKey:"ptpTimescale"            json:"ptpTimescale"`
+	TimeTraceable           int    `fetcherKey:"timeTraceable"           json:"timeTraceable"`
+	FrequencyTraceable      int    `fetcherKey:"frequencyTraceable"      json:"frequencyTraceable"`
+}
+
+// GetAnalyserFormat returns the json expected by the analysers
+func (gmSetting *PMCInfo) GetAnalyserFormat() ([]*callbacks.AnalyserFormatType, error) {
+	formatted := callbacks.AnalyserFormatType{
+		ID: "pmc",
+		Data: []any{
+			gmSetting.TimeSource,
+			gmSetting.ClockAccuracy,
+			gmSetting.OffsetScaledLogVariance,
+			gmSetting.ClockClass,
+			gmSetting.CurrentUtcOffset,
+			gmSetting.Leap61,
+			gmSetting.Leap59,
+			gmSetting.CurrentUtcOffsetValid,
+			gmSetting.PtpTimescale,
+			gmSetting.TimeTraceable,
+			gmSetting.FrequencyTraceable,
+		},
+	}
+	return []*callbacks.AnalyserFormatType{&formatted}, nil
+}
+
+// MapStringToInt converts map string to map int
+func MapStringToInt(inputMap map[string]string) (map[string]int, error) {
+	convertedMap := make(map[string]int)
+	for key, value := range inputMap {
+		convertedValue, err := strconv.Atoi(value)
+		if err != nil {
+			return nil, fmt.Errorf("failed to convert %s into and int", value)
+		}
+
+		convertedMap[key] = convertedValue
+	}
+
+	return convertedMap, nil
+}
+
+var (
+	pmcFetcher *fetcher.Fetcher
+	pmcRegEx   = regexp.MustCompile(
+		`\sclockClass\s+(\d+)` +
+			`\s*clockAccuracy\s+(.+)\n` +
+			`\s*offsetScaledLogVariance\s+(.+)\n` +
+			`\s*currentUtcOffset\s+(\d+)\n` +
+			`\s*leap61\s+(\d+)\n` +
+			`\s*leap59\s+(\d+)\n` +
+			`\s*currentUtcOffsetValid\s+(\d+)\n` +
+			`\s*ptpTimescale\s+(\d+)\n` +
+			`\s*timeTraceable\s+(\d+)\n` +
+			`\s*frequencyTraceable\s+(\d+)\n` +
+			`\s*timeSource\s+(.+)`,
+	// sending: GET GRANDMASTER_SETTINGS_NP
+	// 	507c6f.fffe.30fbe8-0 seq 0 RESPONSE MANAGEMENT GRANDMASTER_SETTINGS_NP
+	// 		clockClass              248
+	// 		clockAccuracy           0xfe
+	// 		offsetScaledLogVariance 0xffff
+	// 		currentUtcOffset        37
+	// 		leap61                  0
+	// 		leap59                  0
+	// 		currentUtcOffsetValid   0
+	// 		ptpTimescale            1
+	// 		timeTraceable           0
+	// 		frequencyTraceable      0
+	// 		timeSource              0xa0
+	)
+)
+
+func init() {
+	pmcFetcher = fetcher.NewFetcher()
+	pmcFetcher.SetPostProcessor(processPMC)
+	err := pmcFetcher.AddNewCommand(
+		"PMC",
+		"pmc -u -f /var/run/ptp4l.0.config  'GET GRANDMASTER_SETTINGS_NP'",
+		true,
+	)
+	if err != nil {
+		panic(fmt.Errorf("failed to setup PMC fetcher %w", err))
+	}
+}
+
+func processPMC(result map[string]string) (map[string]any, error) { //nolint:funlen // allow slightly long function
+	processedResult := make(map[string]any)
+	match := pmcRegEx.FindStringSubmatch(result["PMC"])
+
+	if len(match) == 0 {
+		return processedResult, fmt.Errorf("unable to parse pmc output: %s", result["PMC"])
+	}
+
+	valuesToConvert := map[string]string{
+		"clockClass":            match[1],
+		"currentUtcOffset":      match[4],
+		"leap61":                match[5],
+		"leap59":                match[6],
+		"currentUtcOffsetValid": match[7],
+		"ptpTimescale":          match[8],
+		"timeTraceable":         match[9],
+		"frequencyTraceable":    match[10],
+	}
+
+	convertedMap, err := MapStringToInt(valuesToConvert)
+	if err != nil {
+		return processedResult, err
+	}
+
+	processedResult["timeSource"] = match[11]
+	processedResult["clockAccuracy"] = match[2]
+	processedResult["offsetScaledLogVariance"] = match[3]
+	processedResult["clockClass"] = convertedMap["clockClass"]
+	processedResult["currentUtcOffset"] = convertedMap["currentUtcOffset"]
+	processedResult["leap61"] = convertedMap["leap61"]
+	processedResult["leap59"] = convertedMap["leap59"]
+	processedResult["currentUtcOffsetValid"] = convertedMap["currentUtcOffsetValid"]
+	processedResult["ptpTimescale"] = convertedMap["ptpTimescale"]
+	processedResult["timeTraceable"] = convertedMap["timeTraceable"]
+	processedResult["frequencyTraceable"] = convertedMap["frequencyTraceable"]
+
+	return processedResult, nil
+}
+
+// GetPMC returns PMCInfo
+func GetPMC(ctx clients.ContainerContext) (PMCInfo, error) {
+	gmSetting := PMCInfo{}
+	err := pmcFetcher.Fetch(ctx, &gmSetting)
+	if err != nil {
+		log.Debugf("failed to fetch gmSetting %s", err.Error())
+		return gmSetting, fmt.Errorf("failed to fetch gmSetting %w", err)
+	}
+	return gmSetting, nil
+}

--- a/pkg/collectors/devices/pmc_test.go
+++ b/pkg/collectors/devices/pmc_test.go
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package devices_test
+
+import (
+	"bufio"
+	"net/url"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"k8s.io/client-go/tools/remotecommand"
+
+	"github.com/redhat-partner-solutions/vse-sync-collection-tools/pkg/clients"
+	"github.com/redhat-partner-solutions/vse-sync-collection-tools/pkg/collectors/devices"
+	"github.com/redhat-partner-solutions/vse-sync-collection-tools/testutils"
+)
+
+var _ = Describe("GetPMC", func() {
+	var clientset *clients.Clientset
+	var response map[string][]byte
+	BeforeEach(func() { //nolint:dupl // this is test setup code
+		clientset = testutils.GetMockedClientSet(testPod)
+		response = make(map[string][]byte)
+		responder := func(method string, url *url.URL, options remotecommand.StreamOptions) ([]byte, []byte, error) {
+			reader := bufio.NewReader(options.Stdin)
+			cmd := ""
+			keepReading := true
+			for keepReading {
+				line, prefix, _ := reader.ReadLine()
+				keepReading = prefix
+				cmd += string(line)
+			}
+			return response[cmd], []byte(""), nil
+		}
+		clients.NewSPDYExecutor = testutils.NewFakeNewSPDYExecutor(responder, nil)
+	})
+
+	When("called GetPMC", func() {
+		It("should return a valid GMSettings", func() {
+			expectedInput := "echo '<PMC>';pmc -u -f /var/run/ptp4l.0.config  'GET GRANDMASTER_SETTINGS_NP';echo '</PMC>';"
+
+			expectedOutput := strings.Join([]string{
+				"<PMC>",
+				"sending: GET GRANDMASTER_SETTINGS_NP",
+				"	507c6f.fffe.30fbe8-0 seq 0 RESPONSE MANAGEMENT GRANDMASTER_SETTINGS_NP",
+				"		clockClass              248",
+				"		clockAccuracy           0xfe",
+				"		offsetScaledLogVariance 0xffff",
+				"		currentUtcOffset        37",
+				"		leap61                  0",
+				"		leap59                  0",
+				"		currentUtcOffsetValid   0",
+				"		ptpTimescale            1",
+				"		timeTraceable           0",
+				"		frequencyTraceable      0",
+				"		timeSource              0xa0",
+				"</PMC>",
+			}, "\n")
+			response[expectedInput] = []byte(expectedOutput)
+
+			ctx, err := clients.NewContainerContext(clientset, "TestNamespace", "Test", "TestContainer")
+			Expect(err).NotTo(HaveOccurred())
+
+			pmcInfo, err := devices.GetPMC(ctx)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(pmcInfo.ClockAccuracy).To(Equal("0xfe"))
+			Expect(pmcInfo.ClockClass).To(Equal(248))
+			Expect(pmcInfo.OffsetScaledLogVariance).To(Equal("0xffff"))
+			Expect(pmcInfo.CurrentUtcOffset).To(Equal(37))
+			Expect(pmcInfo.Leap61).To(Equal(0))
+			Expect(pmcInfo.Leap59).To(Equal(0))
+			Expect(pmcInfo.CurrentUtcOffsetValid).To(Equal(0))
+			Expect(pmcInfo.PtpTimescale).To(Equal(1))
+			Expect(pmcInfo.TimeTraceable).To(Equal(0))
+			Expect(pmcInfo.FrequencyTraceable).To(Equal(0))
+			Expect(pmcInfo.TimeSource).To(Equal("0xa0"))
+
+		})
+	})
+})

--- a/pkg/collectors/gps_ubx_collector.go
+++ b/pkg/collectors/gps_ubx_collector.go
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-package collectors
+package collectors //nolint:dupl // new collector
 
 import (
 	"fmt"

--- a/pkg/collectors/pmc_collector.go
+++ b/pkg/collectors/pmc_collector.go
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package collectors //nolint:dupl // new collector
+
+import (
+	"fmt"
+	"sync/atomic"
+
+	"github.com/redhat-partner-solutions/vse-sync-collection-tools/pkg/callbacks"
+	"github.com/redhat-partner-solutions/vse-sync-collection-tools/pkg/clients"
+	"github.com/redhat-partner-solutions/vse-sync-collection-tools/pkg/collectors/contexts"
+	"github.com/redhat-partner-solutions/vse-sync-collection-tools/pkg/collectors/devices"
+	"github.com/redhat-partner-solutions/vse-sync-collection-tools/pkg/utils"
+)
+
+const (
+	PMCCollectorName = "PMC"
+	PMCInfo          = "pmc-info"
+)
+
+type PMCCollector struct {
+	callback     callbacks.Callback
+	ctx          clients.ContainerContext
+	running      bool
+	count        uint32
+	pollInterval int
+}
+
+func (pmc *PMCCollector) GetPollInterval() int {
+	return pmc.pollInterval
+}
+
+func (pmc *PMCCollector) IsAnnouncer() bool {
+	return false
+}
+
+// Start sets up the collector so it is ready to be polled
+func (pmc *PMCCollector) Start() error {
+	pmc.running = true
+	return nil
+}
+
+func (pmc *PMCCollector) poll() error {
+	gmSetting, err := devices.GetPMC(pmc.ctx)
+	if err != nil {
+		return fmt.Errorf("failed to fetch  %s %w", PMCInfo, err)
+	}
+	err = pmc.callback.Call(&gmSetting, PMCInfo)
+	if err != nil {
+		return fmt.Errorf("callback failed %w", err)
+	}
+	return nil
+}
+
+// Poll collects information from the cluster then
+// calls the callback.Call to allow that to persist it
+func (pmc *PMCCollector) Poll(resultsChan chan PollResult, wg *utils.WaitGroupCount) {
+	defer func() {
+		wg.Done()
+		atomic.AddUint32(&pmc.count, 1)
+	}()
+
+	errorsToReturn := make([]error, 0)
+	err := pmc.poll()
+	if err != nil {
+		errorsToReturn = append(errorsToReturn, err)
+	}
+	resultsChan <- PollResult{
+		CollectorName: PMCCollectorName,
+		Errors:        errorsToReturn,
+	}
+}
+
+// CleanUp stops a running collector
+func (pmc *PMCCollector) CleanUp() error {
+	pmc.running = false
+	return nil
+}
+
+func (pmc *PMCCollector) GetPollCount() int {
+	return int(atomic.LoadUint32(&pmc.count))
+}
+
+// Returns a new PMCCollector based on values in the CollectionConstructor
+func NewPMCCollector(constructor *CollectionConstructor) (Collector, error) {
+	ctx, err := contexts.GetPTPDaemonContext(constructor.Clientset)
+	if err != nil {
+		return &PMCCollector{}, fmt.Errorf("failed to create PMCCollector: %w", err)
+	}
+
+	collector := PMCCollector{
+		ctx:          ctx,
+		running:      false,
+		callback:     constructor.Callback,
+		pollInterval: constructor.PollInterval,
+	}
+
+	return &collector, nil
+}
+
+func init() {
+	RegisterCollector(PMCCollectorName, NewPMCCollector, false)
+}


### PR DESCRIPTION
Add a collector to collect data from the PMC (PTP Management Client) command
```
pmc -u -f /var/run/ptp4l.0.config  'GET GRANDMASTER_SETTINGS_NP'
```


Collector output example:
```
*devices.PMCInfo:pmc-info, {"timeSource":"0xa0","clockAccuracy":"0xfe","offsetScaledLogVariance":"0xffff","clockClass":248,"currentUtcOffset":37,"leap61":0,"leap59":0,"currentUtcOffsetValid":0,"ptpTimescale":1,"timeTraceable":0,"frequencyTraceable":0}
```



 