### PR TITLE
Fixed issue which valid version was shown as an error

### DIFF
--- a/pkg/validations/common.go
+++ b/pkg/validations/common.go
@@ -5,6 +5,7 @@ package validations
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"golang.org/x/mod/semver"
 
@@ -44,7 +45,7 @@ type VersionCheck struct {
 }
 
 func (verCheck *VersionCheck) Verify() error {
-	ver := fmt.Sprintf("v%s", verCheck.checkVersion)
+	ver := fmt.Sprintf("v%s", strings.ReplaceAll(verCheck.checkVersion, "_", "-"))
 	if !semver.IsValid(ver) {
 		return fmt.Errorf("could not parse version %s", ver)
 	}

--- a/pkg/validations/device_driver.go
+++ b/pkg/validations/device_driver.go
@@ -17,15 +17,18 @@ const (
 )
 
 var (
-	minDriverVersion       = "1.11.0"
-	minInTreeDriverVersion = "5.14.0"
-
+	minDriverVersion           = "1.11.0"
+	minInTreeDriverVersion     = "5.14.0-0"
 	outOfTreeIceDriverSegments = 3
 )
 
 func NewDeviceDriver(ptpDevInfo *devices.PTPDeviceInfo) *VersionWithErrorCheck {
 	var err error
-	ver := fmt.Sprintf("v%s", ptpDevInfo.DriverVersion)
+	checkVer := ptpDevInfo.DriverVersion
+	if checkVer[len(checkVer)-1] == '.' {
+		checkVer = checkVer[:len(checkVer)-1]
+	}
+	ver := fmt.Sprintf("v%s", strings.ReplaceAll(checkVer, "_", "-"))
 	if semver.IsValid(ver) {
 		if semver.Compare(ver, fmt.Sprintf("v%s", minInTreeDriverVersion)) < 0 {
 			err = fmt.Errorf(
@@ -46,7 +49,7 @@ func NewDeviceDriver(ptpDevInfo *devices.PTPDeviceInfo) *VersionWithErrorCheck {
 		VersionCheck: VersionCheck{
 			id:           deviceDriverVersionID,
 			Version:      ptpDevInfo.DriverVersion,
-			checkVersion: ptpDevInfo.DriverVersion,
+			checkVersion: checkVer,
 			MinVersion:   minDriverVersion,
 			description:  deviceDriverVersionDescription,
 			order:        deviceDriverVersionOrdering,


### PR DESCRIPTION
Version was 5.14.0-284.34.1.rt14.319.el9_2 which is valid however the semver package does not allow underscores in the pre-reslease part of the version also needed to add -0 to the version number to be ordered properly